### PR TITLE
Use generic type conforming Point2DRepresentable for all public interfaces

### DIFF
--- a/Sources/Point2DRepresentable.swift
+++ b/Sources/Point2DRepresentable.swift
@@ -39,25 +39,25 @@ public protocol Point2DRepresentable {
     
     var cgPoint: CGPoint { get }
     
-    func distanceFrom(_ otherPoint: Point2DRepresentable) -> Float
-    func distanceToSegment(_ p1: Point2DRepresentable, _ p2: Point2DRepresentable) -> Float
+    func distanceFrom(_ otherPoint: Self) -> Float
+    func distanceToSegment(_ p1: Self, _ p2: Self) -> Float
     
-    func equalsTo(_ compare: Point2DRepresentable) -> Bool
+    func equalsTo(_ compare: Self) -> Bool
 }
 
 extension Point2DRepresentable {
     
-    public func equalsTo(_ compare: Point2DRepresentable) -> Bool {
+    public func equalsTo(_ compare: Self) -> Bool {
         return self.xValue == compare.xValue && self.yValue == compare.yValue
     }
     
-    public func distanceFrom(_ otherPoint: Point2DRepresentable) -> Float {
+    public func distanceFrom(_ otherPoint: Self) -> Float {
         let dx = self.xValue - otherPoint.xValue
         let dy = self.yValue - otherPoint.yValue
         return (dx * dx) + (dy * dy)
     }
     
-    public func distanceToSegment(_ p1: Point2DRepresentable, _ p2: Point2DRepresentable) -> Float {
+    public func distanceToSegment(_ p1: Self, _ p2: Self) -> Float {
         var x = p1.xValue
         var y = p1.yValue
         var dx = p2.xValue - x

--- a/Sources/SwiftSimplify.swift
+++ b/Sources/SwiftSimplify.swift
@@ -37,7 +37,7 @@ import Foundation
 
 public struct SwiftSimplify {
     
-    public static func simplify(_ points: [Point2DRepresentable], tolerance: Float?, highestQuality: Bool = false) -> [Point2DRepresentable] {
+    public static func simplify<P: Point2DRepresentable>(_ points: [P], tolerance: Float?, highestQuality: Bool = false) -> [P] {
         guard points.count > 1 else {
             return points
         }
@@ -49,14 +49,14 @@ public struct SwiftSimplify {
         return result
     }
     
-    private static func simplifyRadialDistance(_ points: [Point2DRepresentable], tolerance: Float) -> [Point2DRepresentable] {
+    private static func simplifyRadialDistance<P: Point2DRepresentable>(_ points: [P], tolerance: Float) -> [P] {
         guard points.count > 2 else {
             return points
         }
         
         var prevPoint = points.first!
         var newPoints = [prevPoint]
-        var currentPoint: Point2DRepresentable!
+        var currentPoint: P!
         
         for i in 1..<points.count {
             currentPoint = points[i]
@@ -73,7 +73,7 @@ public struct SwiftSimplify {
         return newPoints
     }
     
-    private static func simplifyDPStep(_ points: [Point2DRepresentable], first: Int, last: Int, sqTolerance: Float, simplified: inout [Point2DRepresentable]) {
+    private static func simplifyDPStep<P: Point2DRepresentable>(_ points: [P], first: Int, last: Int, sqTolerance: Float, simplified: inout [P]) {
         
         guard last > first else {
             return
@@ -100,7 +100,7 @@ public struct SwiftSimplify {
         }
     }
     
-    private static func simplifyDouglasPeucker(_ points: [Point2DRepresentable], sqTolerance: Float) -> [Point2DRepresentable] {
+    private static func simplifyDouglasPeucker<P: Point2DRepresentable>(_ points: [P], sqTolerance: Float) -> [P] {
         guard points.count > 1 else {
             return []
         }
@@ -117,7 +117,7 @@ public struct SwiftSimplify {
 
 // MARK: - Array Extension
 
-public extension Array where Element == Point2DRepresentable {
+public extension Array where Element: Point2DRepresentable {
     
     func simplify(tolerance: Float? = nil, highestQuality: Bool = true) -> [Element] {
         return SwiftSimplify.simplify(self, tolerance: tolerance, highestQuality: highestQuality)

--- a/Sources/UIBezierPath+CGPoint.swift
+++ b/Sources/UIBezierPath+CGPoint.swift
@@ -40,7 +40,7 @@ public extension UIBezierPath {
     ///
     /// - Parameter points: points of the path.
     /// - Returns: smoothed UIBezierPath.
-    static func smoothFromPoints(_ points: [Point2DRepresentable]) -> UIBezierPath {
+    static func smoothFromPoints<P: Point2DRepresentable>(_ points: [P]) -> UIBezierPath {
         let path = UIBezierPath()
         guard points.count > 1 else {
             return path


### PR DESCRIPTION
This PR changes all public interfaces for library to accept parameters with generic types conforming `Point2DRepresentable` protocol, which makes return type of the function `SwiftSimplify.simplify(_:tolerance:highestQuality:)` equals the type of the first parameter `points`.