### PR TITLE
Swift 5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/SwiftSimplify/Point2DRepresentable.swift
+++ b/Sources/SwiftSimplify/Point2DRepresentable.swift
@@ -48,12 +48,12 @@ public protocol Point2DRepresentable {
 extension Point2DRepresentable {
     
     public func equalsTo(_ compare: Self) -> Bool {
-        return self.xValue == compare.xValue && self.yValue == compare.yValue
+        xValue == compare.xValue && yValue == compare.yValue
     }
     
     public func distanceFrom(_ otherPoint: Self) -> Float {
-        let dx = self.xValue - otherPoint.xValue
-        let dy = self.yValue - otherPoint.yValue
+        let dx = xValue - otherPoint.xValue
+        let dy = yValue - otherPoint.yValue
         return (dx * dx) + (dy * dy)
     }
     
@@ -83,15 +83,15 @@ extension Point2DRepresentable {
 }
 
 extension CLLocationCoordinate2D: Point2DRepresentable {
-    public var xValue: Float { return Float(self.latitude) }
-    public var yValue: Float { return Float(self.longitude) }
+    public var xValue: Float { Float(latitude) }
+    public var yValue: Float { Float(longitude) }
     
-    public var cgPoint: CGPoint { return CGPoint(x: self.latitude, y: self.longitude) }
+    public var cgPoint: CGPoint { CGPoint(x: latitude, y: longitude) }
 }
 
 extension CGPoint: Point2DRepresentable {
-    public var xValue: Float { return Float(self.x) }
-    public var yValue: Float { return Float(self.y) }
+    public var xValue: Float { Float(x) }
+    public var yValue: Float { Float(y) }
     
-    public var cgPoint: CGPoint { return self }
+    public var cgPoint: CGPoint { self }
 }

--- a/Sources/SwiftSimplify/SwiftSimplify.swift
+++ b/Sources/SwiftSimplify/SwiftSimplify.swift
@@ -35,7 +35,7 @@ import Foundation
 
 // MARK: - SwiftSimplify
 
-public struct SwiftSimplify {
+public enum SwiftSimplify {
     
     public static func simplify<P: Point2DRepresentable>(_ points: [P], tolerance: Float?, highestQuality: Bool = false) -> [P] {
         guard points.count > 1 else {

--- a/Sources/SwiftSimplify/SwiftSimplify.swift
+++ b/Sources/SwiftSimplify/SwiftSimplify.swift
@@ -120,7 +120,7 @@ public struct SwiftSimplify {
 public extension Array where Element: Point2DRepresentable {
     
     func simplify(tolerance: Float? = nil, highestQuality: Bool = true) -> [Element] {
-        return SwiftSimplify.simplify(self, tolerance: tolerance, highestQuality: highestQuality)
+        SwiftSimplify.simplify(self, tolerance: tolerance, highestQuality: highestQuality)
     }
     
 }

--- a/Sources/SwiftSimplify/UIBezierPath+CGPoint.swift
+++ b/Sources/SwiftSimplify/UIBezierPath+CGPoint.swift
@@ -76,7 +76,7 @@ fileprivate extension CGPoint {
     /// - Parameter p2: other point.
     /// - Returns: mid point.
     func midPointForPointsTo(_ p2: CGPoint) -> CGPoint {
-        return CGPoint(x: (x + p2.x) / 2, y: (y + p2.y) / 2)
+        CGPoint(x: (x + p2.x) / 2, y: (y + p2.y) / 2)
     }
     
     /// Control point to another point from receiver.
@@ -84,11 +84,11 @@ fileprivate extension CGPoint {
     /// - Parameter p2: other point.
     /// - Returns: control point for quad curve.
     func controlPointToPoint(_ p2:CGPoint) -> CGPoint {
-        var controlPoint = self.midPointForPointsTo(p2)
+        var controlPoint = midPointForPointsTo(p2)
         let  diffY = abs(p2.y - controlPoint.y)
-        if self.y < p2.y {
+        if y < p2.y {
             controlPoint.y = controlPoint.y + diffY
-        } else if ( self.y > p2.y ) {
+        } else if y > p2.y {
             controlPoint.y = controlPoint.y - diffY
         }
         return controlPoint

--- a/iOSDemoApp/RenderView.swift
+++ b/iOSDemoApp/RenderView.swift
@@ -14,7 +14,7 @@ class RenderView: UIView {
     
 	func renderPath(path: CGPath) {
 		self.path = path
-		self.setNeedsDisplay()
+		setNeedsDisplay()
 	}
 	
     override func draw(_ rect: CGRect) {


### PR DESCRIPTION
 - Use implicit returns
 - Remove unnecessary explicit references to `self`
 - Use enum instead of struct for namespacing to restrict initialization