### PR TITLE
Supports mandatory points to be

### DIFF
--- a/Sources/SwiftSimplify/Point2DRepresentable.swift
+++ b/Sources/SwiftSimplify/Point2DRepresentable.swift
@@ -36,6 +36,7 @@ import CoreLocation
 public protocol Point2DRepresentable {
     var xValue: Float { get }
     var yValue: Float { get }
+    var isMandatory: Bool { get }
     
     var cgPoint: CGPoint { get }
     
@@ -46,6 +47,10 @@ public protocol Point2DRepresentable {
 }
 
 public extension Point2DRepresentable {
+    
+    var isMandatory: Bool {
+        return false
+    }
     
     func equalsTo(_ compare: Self) -> Bool {
         xValue == compare.xValue && yValue == compare.yValue


### PR DESCRIPTION
I added the property `isMandatory` to `Point2DRepresentable`. This allows to mark certain points as mandatory - so that regardless of the simplification process, they're always included in the result.

I'm not sure it's the most efficient way of doing this - for our use case it works very well: We're optimisation a large collection of coordinates (x: latitude, y: longitude) and some coordinates must be included in the optimised collection (i.e. `isMandatory = true`).